### PR TITLE
meeting time shows up for meetings that are currently happening

### DIFF
--- a/src/components/Dashboard/index.js
+++ b/src/components/Dashboard/index.js
@@ -45,6 +45,9 @@ const mapDispatchToProps = dispatch => ({
 
 
 const formatMeetingDuration = (meeting) => {
+  if (!meeting.endTime) {
+    meeting = { ...meeting, endTime: new Date()  };
+  };
   let diff = moment(new Date(meeting.endTime)).diff(moment(new Date(meeting.startTime)), 'minutes');
   return diff + " minutes";
 }


### PR DESCRIPTION
fix: dashboard meeting time shows up when you have a meeting in-progress

## Description
<!--- Describe your changes in detail -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)
- ✅ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
