### PR TITLE
dashboard: select top meeting any time meeting list is reloaded, even…

### DIFF
--- a/src/redux/actions/dashboard.js
+++ b/src/redux/actions/dashboard.js
@@ -85,7 +85,7 @@ export const loadRecentMeetings = (uid, selectedMeeting) => dispatch => {
       }
       meetings.sort((a, b) => /*descending*/ -cmpMeetingsByStartTime(a, b));
       dispatch(updateMeetingList(meetings));
-      if (meetings.length > 0 && selectedMeeting === null) {
+      if (meetings.length > 0) {
         let newSelectedMeeting = meetings[0];
         dispatch(selectMeeting(newSelectedMeeting));
         dispatch(loadMeetingData(newSelectedMeeting._id));


### PR DESCRIPTION
… if another meeting is selected

<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Only setting the selected meeting when there is no current selection when the
meeting list is loaded was therefore frequently not selecting the meeting that the
user just left, and that is more desirable. There may be other consequences, but
we'll see what happens.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
