### PR TITLE
set lower resolution and framerate to help performance

### DIFF
--- a/src/redux/listeners/webrtc.js
+++ b/src/redux/listeners/webrtc.js
@@ -50,6 +50,14 @@ export default function (nick, localVideoNode, dispatch, getState) {
       path: signalmasterPath,
       forceNew: true
     },
+    media: {
+      audio: true,
+      video: {
+        width: { max: 640 },
+        height: { max: 480 },
+        frameRate: { max: 30 }
+      }
+    },
     debug: !!window.client_config.webrtc_debug
   };
 


### PR DESCRIPTION
basically just force < 720p video and lower framerates to help with performance. 

tried forcing h.264 encoding but implementation is trickier than I imagined bc of chrome

## Description
<!--- Describe your changes in detail -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)
- ✅ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
