### PR TITLE
support an LTI launch to target different destination routes after login

### DIFF
--- a/server/routes/lticonfig.js
+++ b/server/routes/lticonfig.js
@@ -31,7 +31,9 @@ function ltiConfig(req, res)
 
   logger.debug({ req, reqUrl: req.url, reqOrigUrl: req.originalUrl, body: req.body }, 'ltiConfig entered...');
 
-  let config = getConfig({ scheme: req.protocol, host: req.hostname });
+  let path = req.query.path || '/room';
+  path = path.startsWith('/') ? path : `/${path}`;
+  let config = getConfig({ scheme: req.protocol, host: req.hostname, path });
   let xmlConfig = js2xml(config, { compact: true, spaces: 2 });
   res.type('text/xml');
   res.send(xmlConfig);
@@ -49,11 +51,17 @@ function ltiConfig(req, res)
  *
  * @returns {Object}
  */
-function getConfig({ scheme = 'https', host = 'localhost' } = {})
+function getConfig({ scheme = 'https', host = 'localhost', path = '/room' } = {})
 {
+  const mapPath =
+    {
+      '/room':  { title: 'Riff Video Chat' },
+      '/riffs': { title: 'Riff Meeting Metrics' },
+      '/':      { title: 'Riff Platform' },
+    };
   // Possibly dynamic (ie we may want to change them at runtime) LTI configuration field(s)
-  let ltiLaunchUrl = `${scheme}://${host}/api/lti/launch`;
-  const toolTitle = 'Riff Chat';
+  let ltiLaunchUrl = `${scheme}://${host}/lti/launch${path}`;
+  const toolTitle = mapPath[path] ? mapPath[path].title : mapPath['/'].title;
 
   /* eslint-disable no-multi-spaces */
   /**

--- a/server/routes/router_spa.js
+++ b/server/routes/router_spa.js
@@ -36,8 +36,10 @@ router.use(
  * after which we will return the SPA index file w/ some extra information
  * in a global window property named `lti_data`.
  */
-if (config.get('server.lti.enabled')) // eslint-disable-line curly
-  router.post('/lti/launch', ltiLaunch, spaIndex);
+if (config.get('server.lti.enabled'))
+{
+  router.post('/lti/launch/:route*', ltiLaunch, spaIndex);
+}
 
 /* GET single page application */
 router.get('*', spaIndex);

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -26,6 +26,7 @@ import addAuthListener from '../redux/listeners/auth';
 import { attemptLoginAnonymous } from '../redux/actions/auth';
 import { attemptRiffAuthenticate } from '../redux/actions/riff';
 import { loginLTIUser } from '../redux/actions/lti';
+import { replace } from 'connected-react-router';
 
 const Footer = styled.footer.attrs({
   className: 'footer'
@@ -61,6 +62,9 @@ const mapDispatchToProps = dispatch => ({
   loginLTIUser: (data) => {
     dispatch(loginLTIUser(data));
   },
+  changeRoute: (path) => {
+    dispatch(replace(path));
+  },
   dispatch: dispatch
 });
 
@@ -80,8 +84,15 @@ class App extends React.Component {
 
     // if window was loaded with LTI data
     if (window.lti_data.lti_user) {
-      console.log("Loaded with LTI data and user.");
+      console.log("Loaded with LTI data and user.", this.props);
       this.props.loginLTIUser(window.lti_data);
+      const ltiLaunchPathPrefix = '/lti/launch';
+      let launchPath = this.props.location.pathname;
+      if (launchPath.startsWith(ltiLaunchPathPrefix)) {
+        launchPath = launchPath.slice(ltiLaunchPathPrefix.length);
+        launchPath = launchPath || '/';
+        this.props.changeRoute(launchPath);
+      }
     } else if (!this.props.auth.user.uid && !this.props.auth.uid) {
       console.log("No user detected, creating anonymous ID");
       this.props.attemptLoginAnonymous();

--- a/src/redux/actions/lti.js
+++ b/src/redux/actions/lti.js
@@ -1,7 +1,6 @@
 import { LTI_LOGIN_USER,
          LTI_LOGOUT_USER,
        } from '../constants/ActionTypes';
-import {push} from 'connected-react-router';
 import {attemptUserCreate, attemptUserSignIn, loginUserSuccess, createUserFail} from './auth';
 import {changeRoomNameState, joinRoom} from './makeMeeting';
 import {changeDisplayName} from './chat';
@@ -53,9 +52,9 @@ export const loginLTIUser = ltiData => dispatch => {
       console.error(`LTI user (${ltiUserEmail}) login or create account failed with code: ${err.code}`);
     })
     .then(() => {
+      // an LTI user cannot set the chat room name or display name so we need to set them now.
       dispatch(joinRoom(ltiRoomName));
       dispatch(changeDisplayName(ltiState.user.fullName));
-      dispatch(push('/room'));
     });
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
- changed the client so that it redirects to the path following /lti/launch instead of always
  going to `/room`
- Made the POST route handler for lti launches support arbitrary trailing paths

- Made a POST to /lti/launch/:route* redirect to the SPA's matching route when it loads.
  In particular we want to support `/lti/launch/room` and `/lti/launch/riffs`, but the code
  now supports any trailing route.

- To go along with that, the `/api/lti/config` endpoint has been modified to accept a
  path query parameter. If not supplied it will default to `/room`. If you want the config
  for the riff dashboard you would GET `/api/lti/config?path=/riffs`. If you want the
  config for the riff platform home you would use `/api/lti/config?path=/`.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of the benefit of using Riff in a course is allowing the students to see the metrics of their meetings and how they may have changed over time. This means that the LMS needs to launch Riff both to start a team meeting for the student, AND launch Riff to show them their meeting metrics which are presented on the dashboard.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Breaking change (fix or feature that would cause existing functionality to change)
    - The endpoint to launch a videochat has changed from `/lti/launch` to `/lti/launch/roo`

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
Documentation for all endpoints is still needed.